### PR TITLE
Utöka Adtraction-skriptet för fler statistikvärden

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-Test
+# Kodning
+
+Detta repo innehåller ett enkelt skript för att hämta statistik från
+Adtractions "om"-sida.
+
+Kör skriptet med
+
+```
+python adtraction_konverteringar_scrape.py
+```
+
+Skriptet sparar resultatet i filen `adtraction_statistics.csv` och
+lägger till en ny rad med aktuell tidsstämpel varje gång det körs.
+


### PR DESCRIPTION
## Summary
- generaliserat hämtningen från Adtractions "om"-sida för att få alla statistikrutor
- loggar resultaten som CSV med tidsstämpel
- uppdaterad README med körinstruktioner

## Testing
- `python adtraction_konverteringar_scrape.py`

------
https://chatgpt.com/codex/tasks/task_e_6899c635d138832cb57ab5bcdaf51314